### PR TITLE
Bump ics to v3

### DIFF
--- a/generate-ics.js
+++ b/generate-ics.js
@@ -56,9 +56,6 @@ const generateIcs = (title, rawEvents, feedUrl = null) => {
 		if (ev.location) {
 			ev.location = ev.location.replace(/,/g, '\\,')
 		}
-
-		ev.calName = title
-		
 		return ev
 	})
 	let {error, value: ics} = formatEvents(events)
@@ -89,6 +86,7 @@ const generateIcs = (title, rawEvents, feedUrl = null) => {
 		const endI = markerI + methodPublish.length
 		ics = [
 			ics.slice(0, endI),
+			`X-WR-CALNAME:${title}\r\n`,
 			feedUrl ? `X-ORIGINAL-URL:${feedUrl}\r\n` : '',
 			ics.slice(endI),
 		].join('')

--- a/generate-ics.js
+++ b/generate-ics.js
@@ -56,6 +56,9 @@ const generateIcs = (title, rawEvents, feedUrl = null) => {
 		if (ev.location) {
 			ev.location = ev.location.replace(/,/g, '\\,')
 		}
+
+		ev.calName = title
+		
 		return ev
 	})
 	let {error, value: ics} = formatEvents(events)
@@ -86,7 +89,6 @@ const generateIcs = (title, rawEvents, feedUrl = null) => {
 		const endI = markerI + methodPublish.length
 		ics = [
 			ics.slice(0, endI),
-			`X-WR-CALNAME:${title}\r\n`,
 			feedUrl ? `X-ORIGINAL-URL:${feedUrl}\r\n` : '',
 			ics.slice(endI),
 		].join('')

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"escape-goat": "^3.0.0",
-		"ics": "^2.19.0"
+		"ics": "^3.1.0"
 	},
 	"devDependencies": {
 		"connect": "^3.7.0",


### PR DESCRIPTION
Bumps ics dependecy to v3
This would solve [seebruecke-events-calendar-feed#7](https://github.com/derhuerst/seebruecke-events-calendar-feed/issues/7)

Removed custom calendar name defintion as this is now supported by ics package itself  ([ics@2.22.0](https://github.com/adamgibbons/ics/releases/tag/v2.22.0))